### PR TITLE
Fix mixed short leg inference for option lots

### DIFF
--- a/Options_dashboard_ChatGPT_Final.ipynb
+++ b/Options_dashboard_ChatGPT_Final.ipynb
@@ -255,7 +255,7 @@
     "            lots.append(lot)\n",
     "\n",
     "        elif (\"put/call\" in t_raw.lower()) or (\"call/put\" in t_raw.lower()):\n",
-    "            short_leg, short_strike = infer_mixed_short_leg(r)\n",
+    "            short_leg, short_strike = infer_mixed_short_leg(r._asdict())\n",
     "            if pd.isna(short_strike):\n",
     "                continue\n",
     "            lot = OptionLot(\n",


### PR DESCRIPTION
## Summary
- Convert namedtuple rows to dictionaries before inferring the short leg, preventing AttributeError when iterating over DataFrame rows.

## Testing
- `python -m py_compile Options_dashboard_ChatGPT_Final.txt`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68a1a48f9c408331b55960a38460512a