### PR TITLE
Handle NaT expirations in option closeout matching

### DIFF
--- a/Options_dashboard_ChatGPT_Final.ipynb
+++ b/Options_dashboard_ChatGPT_Final.ipynb
@@ -26,15 +26,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Downloading workbook …\n",
+      "Downloading workbook \u2026\n",
       "Downloaded: /content/IBKR_Portfolio_sheets.xlsx\n"
      ]
     }
    ],
    "source": [
     "# =========================================================\n",
-    "# Options Income Strategy — Full Profitability & Capital Analysis\n",
-    "# Integrated with your download snippet (Google Sheets → Excel via curl)\n",
+    "# Options Income Strategy \u2014 Full Profitability & Capital Analysis\n",
+    "# Integrated with your download snippet (Google Sheets \u2192 Excel via curl)\n",
     "# - Assignment detection: ONLY the word \"assigned\" in Comment\n",
     "# - Side inferred from Type; handles \"Put/Call\" and \"Call/Put\" (strike like \"A/B\")\n",
     "# - Capital: cash-secured short puts + cash tied in assigned shares (per-lot FIFO segments)\n",
@@ -50,7 +50,7 @@
     "SHEET_ID = \"19LhrZai3cbJ1GbPE1iTquYHUeXfpIxXFX1amF5eWi_g\"   # <-- paste only the ID string\n",
     "FILE = 'IBKR_Portfolio_sheets.xlsx'\n",
     "\n",
-    "print('Downloading workbook …')\n",
+    "print('Downloading workbook \u2026')\n",
     "url = f'https://docs.google.com/spreadsheets/d/{SHEET_ID}/export?format=xlsx'\n",
     "subprocess.run(shlex.split(f'curl -L -o {FILE} {url}'), check=True)\n",
     "print(f'Downloaded: {os.path.abspath(FILE)}')\n",
@@ -66,7 +66,7 @@
     "EXCEL_PATH = FILE\n",
     "SHEETS = [\"Options 2024\", \"Options 2025\"]\n",
     "CONTRACT_MULTIPLIER = 100\n",
-    "AS_OF_DATE: Optional[str] = None   # e.g., \"2025-08-16\"; None → today\n",
+    "AS_OF_DATE: Optional[str] = None   # e.g., \"2025-08-16\"; None \u2192 today\n",
     "INCLUDE_UNREALIZED_IN_CURRENT_YEAR = True\n",
     "EXPORT_REPORT_PATH = \"options_profitability_report.xlsx\"\n"
    ]
@@ -280,16 +280,20 @@
     "    \"\"\"Match Buy rows to earliest open short (ticker, type, strike, expiration) and close earlier.\"\"\"\n",
     "    key_to_indices: Dict[Tuple, List[int]] = defaultdict(list)\n",
     "    for i, lot in enumerate(lots):\n",
-    "        key = (lot.ticker, lot.otype, lot.strike, pd.to_datetime(lot.expiration).normalize())\n",
+    "        exp = pd.to_datetime(lot.expiration)\n",
+    "        exp = exp.normalize() if pd.notna(exp) else pd.NaT\n",
+    "        key = (lot.ticker, lot.otype, lot.strike, exp)\n",
     "        key_to_indices[key].append(i)\n",
     "\n",
     "    buys = df[(df[\"action\"]==\"Buy\") & (df[\"type\"].isin([\"Put\",\"Call\"]))].copy()\n",
     "    buys = buys.sort_values(\"trans_date\")\n",
     "    for _, b in buys.iterrows():\n",
+    "        exp = pd.to_datetime(b[\"expiration\"])\n",
+    "        exp = exp.normalize() if pd.notna(exp) else pd.NaT\n",
     "        key = (str(b[\"ticker\"]).upper().strip(),\n",
     "               str(b[\"type\"]),\n",
     "               float(b[\"strike\"]),\n",
-    "               pd.to_datetime(b[\"expiration\"]).normalize())\n",
+    "               exp)\n",
     "        indices = key_to_indices.get(key, [])\n",
     "        if not indices:\n",
     "            continue\n",
@@ -302,7 +306,7 @@
     "                break\n",
     "\n",
     "lots = build_short_lots_from_rows(df_opts)\n",
-    "apply_buy_to_close_closeouts(lots, df_opts)"
+    "apply_buy_to_close_closeouts(lots, df_opts)\n"
    ]
   },
   {
@@ -452,7 +456,7 @@
     "    cost_per_share: float\n",
     "\n",
     "def build_holding_segments(txns: List[StockTxn], as_of: pd.Timestamp) -> List[HoldSeg]:\n",
-    "    \"\"\"Build per-lot holding segments using FIFO. Each BUY portion sold generates a segment [buy, sell). Unsold → [buy, as_of).\"\"\"\n",
+    "    \"\"\"Build per-lot holding segments using FIFO. Each BUY portion sold generates a segment [buy, sell). Unsold \u2192 [buy, as_of).\"\"\"\n",
     "    open_buys: Dict[str, List[OpenLot]] = defaultdict(list)\n",
     "    segs: List[HoldSeg] = []\n",
     "    for t in sorted(txns, key=lambda x: (x.date, x.ticker)):\n",
@@ -1141,7 +1145,7 @@
     "\n",
     "print(\"\\n\")\n",
     "\n",
-    "# 2) Annualized return on average capital (realized) — 2024 vs 2025\n",
+    "# 2) Annualized return on average capital (realized) \u2014 2024 vs 2025\n",
     "if \"annualized_return_on_avg\" in yr.columns:\n",
     "    ret_vals = [float(yr.loc[y, \"annualized_return_on_avg\"]) for y in years_order]\n",
     "    fig, ax = plt.subplots(figsize=(7, 4.5))\n",
@@ -1283,7 +1287,7 @@
    ],
    "source": [
     "# ============================\n",
-    "# Risk metrics: Sortino & Max Drawdown (monthly) — CLEAN\n",
+    "# Risk metrics: Sortino & Max Drawdown (monthly) \u2014 CLEAN\n",
     "# Requires: monthly, as_of_date\n",
     "# ============================\n",
     "import pandas as pd, numpy as np\n",
@@ -1489,7 +1493,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Monthly Expectancy — P&L\n"
+      "Monthly Expectancy \u2014 P&L\n"
      ]
     },
     {
@@ -1542,7 +1546,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Monthly Expectancy — Returns\n"
+      "Monthly Expectancy \u2014 Returns\n"
      ]
     },
     {
@@ -1593,7 +1597,7 @@
    ],
    "source": [
     "# ============================================\n",
-    "# Expectancy blocks — clean formatting (no dependency on prior _format_styler)\n",
+    "# Expectancy blocks \u2014 clean formatting (no dependency on prior _format_styler)\n",
     "# ============================================\n",
     "import pandas as pd, numpy as np\n",
     "\n",
@@ -1673,13 +1677,13 @@
     "\n",
     "\n",
     "# -----------------------------\n",
-    "# PER-MONTH — P&L & RETURN\n",
+    "# PER-MONTH \u2014 P&L & RETURN\n",
     "# -----------------------------\n",
     "# Use \"monthly\" DataFrame built from option cycles\n",
     "pnl_stats = expectancy_from_series(monthly[\"combined_realized_m\"])\n",
     "monthly_pnl_metrics = pd.DataFrame([pnl_stats], index=[\"Monthly P&L\"])\n",
     "\n",
-    "print(\"\\nMonthly Expectancy — P&L\")\n",
+    "print(\"\\nMonthly Expectancy \u2014 P&L\")\n",
     "display(fmt_styler(\n",
     "    monthly_pnl_metrics,\n",
     "    money=[\"Avg win\",\"Avg loss\",\"Expectancy ($)\",\"Total P&L ($)\"],\n",
@@ -1706,7 +1710,7 @@
     "        \"Expectancy (return)\": np.nan, \"Total Return\": np.nan\n",
     "    }], index=[\"Monthly Returns\"])\n",
     "\n",
-    "print(\"\\nMonthly Expectancy — Returns\")\n",
+    "print(\"\\nMonthly Expectancy \u2014 Returns\")\n",
     "display(fmt_styler(\n",
     "    monthly_ret_metrics,\n",
     "    money=[],\n",
@@ -2297,7 +2301,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Performance metrics — proper (TWR + cap-weighted proxy):\n"
+      "Performance metrics \u2014 proper (TWR + cap-weighted proxy):\n"
      ]
     },
     {
@@ -2354,7 +2358,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Benchmark panel — aligned window:\n"
+      "Benchmark panel \u2014 aligned window:\n"
      ]
     },
     {
@@ -2431,7 +2435,7 @@
    ],
    "source": [
     "# ======================================================================\n",
-    "# ADD-ON v4.0 — Dividends, Proper Performance Metrics (TWR + Cap-Weighted Proxy),\n",
+    "# ADD-ON v4.0 \u2014 Dividends, Proper Performance Metrics (TWR + Cap-Weighted Proxy),\n",
     "#               Robust Benchmark Panel, Compact Formatting (no trailing zeros)\n",
     "#\n",
     "# PREREQUISITES (expected from earlier cells in your notebook):\n",
@@ -2443,8 +2447,8 @@
     "#\n",
     "# OUTPUT SECTIONS:\n",
     "#   1) Yearly performance (with dividends)\n",
-    "#   2) Performance metrics — proper (TWR + cap-weighted proxy)\n",
-    "#   3) Benchmark panel — aligned window (Strategy vs. PUT/BXM/dividend ETF)\n",
+    "#   2) Performance metrics \u2014 proper (TWR + cap-weighted proxy)\n",
+    "#   3) Benchmark panel \u2014 aligned window (Strategy vs. PUT/BXM/dividend ETF)\n",
     "# ======================================================================\n",
     "\n",
     "import pandas as pd, numpy as np\n",
@@ -2732,7 +2736,7 @@
     "        \"Cap-Weighted Return (ann, proxy)\",\"Ann. Vol\",\"Sortino (ann)\",\"Max DD %\"\n",
     "    ])\n",
     "\n",
-    "    print(\"\\nPerformance metrics — proper (TWR + cap-weighted proxy):\")\n",
+    "    print(\"\\nPerformance metrics \u2014 proper (TWR + cap-weighted proxy):\")\n",
     "    display(_render_table(\n",
     "        perf_df.assign(**{\n",
     "            # Trim Sortino to 2 decimals without trailing zeros\n",
@@ -2879,7 +2883,7 @@
     "            \"Max DD %\": m[\"mdd_pct\"]\n",
     "        })\n",
     "    bench_panel = pd.DataFrame(rows).sort_values([\"Series\"]).reset_index(drop=True)\n",
-    "    print(\"\\nBenchmark panel — aligned window:\")\n",
+    "    print(\"\\nBenchmark panel \u2014 aligned window:\")\n",
     "    from IPython.display import display\n",
     "    display(_render_table(\n",
     "        bench_panel.assign(**{\n",
@@ -2981,7 +2985,7 @@
     "        int_cols=[\"Window (months)\"]\n",
     "    )\n",
     "    print(\"\n",
-    "Performance metrics — proper (TWR + cap-weighted proxy):\")\n",
+    "Performance metrics \u2014 proper (TWR + cap-weighted proxy):\")\n",
     "    display(perf_table)\n",
     "except Exception as e:\n",
     "    print(\"[metrics] Unable to compute performance metrics:\", e)\n",
@@ -2989,7 +2993,7 @@
     "# Benchmark panel reuse\n",
     "try:\n",
     "    print(\"\n",
-    "Benchmark panel — aligned window:\")\n",
+    "Benchmark panel \u2014 aligned window:\")\n",
     "    bench_table = _render_table(\n",
     "        bench_panel.assign(**{\n",
     "            \"Sortino (ann)\": bench_panel[\"Sortino (ann)\"].map(lambda x: \"\" if pd.isna(x) else f\"{x:.2f}\".rstrip(\"0\").rstrip(\".\")),\n",


### PR DESCRIPTION
## Summary
- Safely normalize option expiration dates only when valid
- Avoid AttributeError in apply_buy_to_close_closeouts when expiration is NaT

## Testing
- `python - <<'PY'
import json, pandas as pd, math
from typing import List, Tuple, Dict
from collections import defaultdict
from dataclasses import dataclass
nb=json.load(open('Options_dashboard_ChatGPT_Final.ipynb'))
source=nb['cells'][3]['source'][:-2]
ns={'pd':pd,'math':math,'List':List,'Tuple':Tuple,'Dict':Dict,'defaultdict':defaultdict,'dataclass':dataclass}
exec(''.join(source), ns)
OptionLot=ns['OptionLot']
apply=ns['apply_buy_to_close_closeouts']
lots=[OptionLot(ticker='AAPL',otype='Call',strike=150,qty=1,open_date=pd.Timestamp('2024-01-01'),expiration=pd.NaT,premium_net=0.0,comment='',assigned=False,close_date=pd.Timestamp('2024-12-31'),close_reason='expiration')]
rows=[{'ticker':'AAPL','type':'Call','strike':150.0,'action':'Buy','trans_date':pd.Timestamp('2024-01-10'), 'expiration':pd.NaT}]
df=pd.DataFrame(rows)
apply(lots, df)
print('Close date:', lots[0].close_date, 'Reason:', lots[0].close_reason)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a1b01003388331b4410f0326db5297