### PR TITLE
Fix notebook indentation errors

### DIFF
--- a/Options_dashboard_ChatGPT_Final.ipynb
+++ b/Options_dashboard_ChatGPT_Final.ipynb
@@ -1306,7 +1306,7 @@
     "        if not hist.empty:\n",
     "            return float(hist[\"Close\"].dropna().iloc[-1]) / 100.0\n",
     "    except Exception as e:\n",
-    "    return float(default)\n",
+    "        return float(default)\n",
     "\n",
     "BENCHMARK = \"rf\"\n",
     "RISK_FREE_ANNUAL = _get_usd_risk_free_annual(default=0.05)\n",
@@ -2618,6 +2618,7 @@
     "        yearly_with_div[\"annualized_return_on_avg_w_div\"]  = yearly_with_div.apply(lambda r: _ann(r, \"return_on_avg_w_div\"), axis=1)\n",
     "        yearly_with_div[\"annualized_return_on_peak_w_div\"] = yearly_with_div.apply(lambda r: _ann(r, \"return_on_peak_w_div\"), axis=1)\n",
     "except NameError:\n",
+    "    pass\n",
     "\n",
     "# Display yearly with dividends\n",
     "try:\n",
@@ -2734,6 +2735,7 @@
     "        # NOTE: do not pass float_cols for Sortino since we pre-formatted it as string\n",
     "    ))\n",
     "except Exception as e:\n",
+    "    pass\n",
     "\n",
     "# ----------------------------- Benchmarks ----------------------------- #\n",
     "\n",
@@ -2877,7 +2879,8 @@
     "        int_cols=[\"Months\"]\n",
     "        # Note: do not pass float_cols for Sortino (we preformatted it)\n",
     "    ))\n",
-    "else:"
+    "else:\n",
+    "    print(\"No overlapping benchmark data\")"
    ]
   },
   {
@@ -2936,6 +2939,7 @@
     "    )\n",
     "    display(yearly_table)\n",
     "except Exception as e:\n",
+    "    print(e)\n",
     "\n",
     "# Performance metrics with Sharpe\n",
     "try:\n",
@@ -2964,6 +2968,7 @@
     "    )\n",
     "    display(perf_table)\n",
     "except Exception as e:\n",
+    "    print(e)\n",
     "\n",
     "# Benchmark panel reuse\n",
     "try:\n",
@@ -2976,6 +2981,7 @@
     "    )\n",
     "    display(bench_table)\n",
     "except Exception as e:\n",
+    "    print(e)\n",
     "\n",
     "# Yearly return comparison plot\n",
     "try:\n",


### PR DESCRIPTION
## Summary
- Resolve missing return in risk-free rate helper
- Add fallback handling when benchmark data is absent
- Ensure exception blocks in dashboard display print errors instead of breaking

## Testing
- `python - <<'PY'
import nbformat
nb = nbformat.read(open('Options_dashboard_ChatGPT_Final.ipynb'), as_version=4)
for i, cell in enumerate(nb.cells):
    if cell['cell_type'] == 'code':
        src = ''.join(cell['source'])
        compile(src, f'cell_{i}', 'exec')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a1b928cd088331a430736f18ce5c09